### PR TITLE
Remove VLA for MSVC Support

### DIFF
--- a/meow_fft.h
+++ b/meow_fft.h
@@ -598,10 +598,10 @@ void meow_dft_n_dit
                 sum.j += jj;
             }
 
-            free(scratch);
             out[index_out] = sum;
         }
     }
+    free(scratch);
 }
 
 // -----------------------------------------------------------------------------


### PR DESCRIPTION
MSVC does not support variable length arrays (VLAs).
In order to compile, a malloc/free is used instead.

---

Changes tested on Windows using CMake 3.20.1 with the following compiler toolchain

- Building for: Visual Studio 16 2019
- Selecting Windows SDK version 10.0.19041.0 to target Windows 10.0.19043.
- The C compiler identification is MSVC 19.29.30136.0

Prior to the change, a minimum working example based off the example in the `README.md` would not compile.
It resulted in the following compiler error messages:

```
meow_fft.h(561,35): error C2057: expected constant expression
meow_fft.h(561,35): error C2466: cannot allocate an array of constant size 0
```

Post change, the example program builds and runs as expected.

No benchmarking has been performed.

The following `main.c` and `CMakeLists.txt` files were used for the MWE:

```cmake
cmake_minimum_required(VERSION 3.3)

project(meow_fft LANGUAGES C)

set(CMAKE_C_STANDARD 99)
set(CMAKE_C_STANDARD_REQUIRED ON)

add_executable(main_c main.c)
target_include_directories(main_c PRIVATE "${CMAKE_CURRENT_SOURCE_DIR}")
target_compile_options(main_c PRIVATE $<$<C_COMPILER_ID:MSVC>:/wd4133>)
```

```c
#define MEOW_FFT_IMPLEMENTATION
#include <meow_fft.h>

#include <malloc.h>

void main()
{
    unsigned          N    = 1024;
    float*            in   = malloc(sizeof(float) * N);
    Meow_FFT_Complex* out  = malloc(sizeof(Meow_FFT_Complex) * N);
    Meow_FFT_Complex* temp = malloc(sizeof(Meow_FFT_Complex) * N);

    // prepare data for "in" array.
    // ...

    size_t workset_bytes = meow_fft_generate_workset_real(N, NULL);
    // Get size for a N point fft working on non-complex (real) data.

    Meow_FFT_Workset_Real* fft_real =
        (Meow_FFT_Workset_Real*) malloc(workset_bytes);

    meow_fft_generate_workset_real(N, fft_real);

    meow_fft_real(fft_real, in, out);
    // out[0].r == out[0  ].r
    // out[0].j == out[N/2].r

    meow_fft_real_i(fft_real, in, temp, out);
    // result is not scaled, need to divide all values by N

    free(fft_real);
    free(out);
    free(temp);
    free(in);
}
```